### PR TITLE
Lipid grid fixed area per bin

### DIFF
--- a/pybilt/bilayer_analyzer/bilayer_analyzer.py
+++ b/pybilt/bilayer_analyzer/bilayer_analyzer.py
@@ -213,6 +213,15 @@ class BilayerAnalyzer(object):
                 specific lipid types and containing a list of atom names to be
                 used when computing the centers-of-mass of lipids of that type.
                 Default: None
+            com_frame:multi_bead (bool): A boolean that is used to determine
+                if the COMFrame assigns a separate bead to each reference atom
+                supplied in the name_dict option. Default: False
+            com_frame:make_whole (bool): A boolean that used to determine if
+                each lipid should be made whole (if they broken by atom
+                wrapping). If True this option calls the make_whole function
+                from MDAnalysis and thus requires that the structure file
+                include bonds (e.g. a psf file instead of a pdb file).
+                Default: False
             leaflets:dump (bool): Determines whether the leaflets are dumped
                 to disc (as pickles) after each frame in the analysis loop.
                 Default: False
@@ -245,6 +254,11 @@ class BilayerAnalyzer(object):
                 use in the 'x' dimension of the LipidGrid objects. Default: 10
             lipid_grid:nybins (int): An integer defining the number of bins to
                 use in the 'y' dimension of the LipidGrid objects. Default: 10
+            lipid_grid:area_per_bin (float): Option to set a fixed area per
+                grid element (i.e. the number of bins will auto adjust each
+                frame to keep the element area appproximately constant). If set,
+                this option overides the nxbins and nybins options. 
+                Default: None
             vector_frame:dump (bool): Determines wheter the VectorFrame objects
                 built during interations of the analysis loop are dumped to
                 disc as pickle files. Default: False

--- a/pybilt/bilayer_analyzer/bilayer_analyzer.py
+++ b/pybilt/bilayer_analyzer/bilayer_analyzer.py
@@ -326,7 +326,8 @@ class BilayerAnalyzer(object):
         self.rep_settings['lipid_grid'] = {'dump' : False,
                                            'dump_path' : "./",
                                            'n_xbins' : 10,
-                                           'n_ybins' : 10}
+                                           'n_ybins' : 10,
+                                           'area_per_bin': None}
         #com_frame
         self.reps['vector_frame'] = None
         self.rep_settings['vector_frame'] = {'dump' : False,
@@ -846,6 +847,7 @@ class BilayerAnalyzer(object):
             resid = lipcom.resid
             tail_str = "resname {} and resid {} and name {}".format(resname, resid,self.rep_settings['leaflets']['orientation_atoms'][resname][0])
             tail = self._mda_data.mda_universe.select_atoms(tail_str)
+            # print(tail, len(tail))
             tail_v = tail.center_of_mass()
             head_str = "resname {} and resid {} and name {}".format(resname, resid,self.rep_settings['leaflets']['orientation_atoms'][resname][1])
             head = self._mda_data.mda_universe.select_atoms(head_str)
@@ -858,7 +860,9 @@ class BilayerAnalyzer(object):
             norm_vec = np.zeros(3)
             norm_vec[norm] = 1.0
             cost = np.dot(vec, norm_vec)/np.sqrt(np.dot(vec, vec))
-            # print(cost)
+            # print(tail_str, head_str)
+            # print(tail_v, head_v, cost)
+            # print(" ")
             pos = ""
             if cost > 0.0:
                 pos = 'upper'
@@ -992,7 +996,8 @@ class BilayerAnalyzer(object):
                 self.reps['lipid_grid'] = lg.LipidGrids(self.reps['com_frame'], self.reps['leaflets'],
                                                 self.settings['lateral'],
                                                 nxbins=self.rep_settings['lipid_grid']['n_xbins'],
-                                                nybins=self.rep_settings['lipid_grid']['n_ybins'])
+                                                nybins=self.rep_settings['lipid_grid']['n_ybins'],
+                                                area_per_bin=self.rep_settings['lipid_grid']['area_per_bin'])
                 if self.rep_settings['lipid_grid']['dump']:
                     ofname = self.rep_settings['lipid_grid']['dump_path'] + "lipid_grid_" + str(
                         frame.frame) + ".pickle"

--- a/pybilt/bilayer_analyzer/com_frame.py
+++ b/pybilt/bilayer_analyzer/com_frame.py
@@ -405,7 +405,7 @@ class COMFrame(object):
                 output.append(lipid.type)
         return output
 
-    def write_xyz(self, xyz_name, wrapped=True):
+    def write_xyz(self, xyz_name, wrapped=True, name_by_leaflet=False):
         # Open up the file to write to
         xyz_out = open(xyz_name, "w")
 
@@ -429,7 +429,8 @@ class COMFrame(object):
 
             #get the lipid resname
             oname = self.lipidcom[i].type
-
+            if name_by_leaflet:
+                oname = self.lipidcom[i].leaflet
             #write to file
             line = str(oname)+" "+str(x)+" "+str(y)+" "+str(z)
             xyz_out.write(line)

--- a/pybilt/bilayer_analyzer/leaflet.py
+++ b/pybilt/bilayer_analyzer/leaflet.py
@@ -71,7 +71,7 @@ class Leaflet(object):
             self.groups[0].add_member(com_index)
             self.group_dict.update({resname: 0})
         else:
-            self.members.append([com_index, resname])
+            self.members.append([com_index, resname, resid])
             addgroup = True
             group_ind = 0
             for rn in self.groups:
@@ -117,6 +117,39 @@ class Leaflet(object):
 
         return list(indices)
 
+    def get_group_indices_per_resid(self, group_name):
+        """ Get the indices of lipids in the Leaflet belonging to a specific LipidGroup.
+
+        Args:
+        group_name (string): The name of the LipidGroup pull LipidCOM indices from.
+            Passing the string 'all' will return indices of all the lipids assigned to
+            the Leaflet instance. If the group_name is not recognised (i.e. is not in the group_dict)
+            The function defaults to 'all'.
+
+        Returns:
+            list of int: A list containing the integer indices of lipids in the Leaflet that
+                belong to the specified LipidGroup.
+        """
+        ret_indices = {}
+        if group_name == "all":
+            indices = self.get_member_indices()
+        elif group_name in self.group_dict:
+            gindex = self.group_dict[group_name]
+            indices = self.groups[gindex].lg_members
+
+        else:
+            #unkwown group name- print warning and use the default "all"
+            print("!! Warning - request for unknown Lipid Group \'",group_name,"\' from the ",self.name," leaflet")
+            print("!! using the default \"all\"")
+            return self.get_member_indices()
+        for i in indices:
+            resid = self.get_member_resid_from_index(i)
+            if resid not in ret_indices.keys():
+                ret_indices[resid] = [i]
+            else:
+                ret_indices[resid].append(i)
+        return ret_indices
+
     def get_member_indices(self):
         """ Get the indices of all lipids (LipidCOM) in the Leaflet.
         This member function Returns: the list of indices for the lipids grouped in the Leaflet instance.
@@ -153,6 +186,14 @@ class Leaflet(object):
         if resid in resids:
             index = resids.index(resid)
             return self.get_member_resnames()[index]
+        else:
+            raise ValueError('resid is not in this leaflet')
+
+    def get_member_resid_from_index(self, index):
+        indices = self.get_member_indices()
+        if index in indices:
+            ind = indices.index(index)
+            return self.get_member_resids()[ind]
         else:
             raise ValueError('resid is not in this leaflet')
 

--- a/pybilt/bilayer_analyzer/mda_data.py
+++ b/pybilt/bilayer_analyzer/mda_data.py
@@ -23,6 +23,10 @@ class MDAData(object):
         self.natoms = len(self.bilayer_sel)
         self.indices = self.bilayer_sel.indices
         self.residues = self.bilayer_sel.residues
+        # make sure each lipid residue has a unique resid
+        # for i, residue in enumerate(self.residues):
+        #    residue.resid = i
+
         self.n_residues = len(self.residues)
         print((list(self.__dict__.keys())))
 

--- a/pybilt/lipid_grid/lipid_grid_opt.py
+++ b/pybilt/lipid_grid/lipid_grid_opt.py
@@ -153,7 +153,7 @@ class LipidGrid2d(object):
 
     """
     def __init__(self, com_frame, com_frame_indices, plane, nxbins=50,
-                 nybins=50):
+                 nybins=50, area_per_bin=None):
         """Initialize the LipidGrid2d object.
         This version of the LipidGrid2d object uses a k-neareset neighbors
         (knn) based algorithm to assign lipids to grid points. The method runs
@@ -189,6 +189,13 @@ class LipidGrid2d(object):
         box = com_frame.box[plane]
         boxx = box[ix]
         boxy = box[iy]
+        # adjust bin counts for fixed resolution
+        if area_per_bin is not None:
+            nbins = np.sqrt((boxx*boxy)/area_per_bin)
+            x2y = boxx/boxy
+            x2y_sr = np.sqrt(x2y)
+            nxbins = int(nbins*x2y_sr)
+            nybins = int(nbins/x2y_sr)
         # save the numbers of bins
         self.x_nbins = nxbins
         self.y_nbins = nybins
@@ -461,7 +468,7 @@ class LipidGrid2d(object):
         return knn
 
 class LipidGrids(object):
-    def __init__(self, com_frame, leaflets, plane, nxbins=50, nybins=50):
+    def __init__(self, com_frame, leaflets, plane, nxbins=50, nybins=50, area_per_bin=None):
         #store the frame and leaflet
         self.frame = com_frame
         self.leaflets = leaflets
@@ -476,12 +483,14 @@ class LipidGrids(object):
         upper_indices = leaflets['upper'].get_member_indices()
         self.leaf_grid['upper'] = LipidGrid2d(com_frame, upper_indices,
                                               plane, nxbins=nxbins,
-                                              nybins=nybins)
+                                              nybins=nybins,
+                                              area_per_bin=area_per_bin)
         #lower
         lower_indices = leaflets['lower'].get_member_indices()
         self.leaf_grid['lower'] = LipidGrid2d(com_frame, lower_indices,
                                               plane, nxbins=nxbins,
-                                              nybins=nybins)
+                                              nybins=nybins,
+                                              area_per_bin=area_per_bin)
         return
 
     def thickness_grid(self):

--- a/pybilt/lipid_grid/lipid_grid_opt.py
+++ b/pybilt/lipid_grid/lipid_grid_opt.py
@@ -406,6 +406,25 @@ class LipidGrid2d(object):
         xyz_out.close()
         return
 
+    def average_per_lipid_type(self, input_grid):
+        vals_per_type = dict()
+        for i,x in enumerate(self.x_centers):
+            for j,y in enumerate(self.y_centers):
+                    l_com_ind = self.lipid_grid[i,j]
+                    ltype = self.frame.lipidcom[l_com_ind].type
+                    l_val = input_grid[i,j]
+                    # print(ltype)
+                    if ltype not in vals_per_type.keys():
+                        vals_per_type[ltype] = [l_val]
+                    else:
+                        vals_per_type[ltype].append(l_val)
+        avgs_per_lipid_type = dict()
+        for key in vals_per_type.keys():
+            avg = np.array(vals_per_type[key]).mean()
+            avgs_per_lipid_type[key] = avg
+
+        return avgs_per_lipid_type
+
     @staticmethod
     def _knn(com_frame, com_frame_indices, plane):
         # get the x and y indices

--- a/pybilt/plot_generation/plot_generation_functions.py
+++ b/pybilt/plot_generation/plot_generation_functions.py
@@ -54,7 +54,7 @@ sns.set_style("ticks")
 _color_list = ['blue', 'green','orange','purple', 'black', 'red', 'yellow', 'gray']
 
 
-def plot(dat_list,yerr_list=None, name_list=None,filename='plot.eps', save=True, show=False, xlabel=None, ylabel=None,
+def plot(dat_list,yerr_list=None, xerr_list=None, name_list=None,filename='plot.eps', save=True, show=False, xlabel=None, ylabel=None,
          marker=None, linestyle=None, xticks=None):
     """Generic plotting function for (multiple) xy datasets.
 


### PR DESCRIPTION
Added the option to use a fixed area per grid element when constructing the lipid grid representations at each frame. It automatically adjusts the numbers of bins along the bilayer lateral dimensions. It also accounts for the relative sizes of the box dimensions so that rectangular bilayer patches are handled appropriately. 