### PR TITLE
Block average bse vs length function

### DIFF
--- a/pybilt/bilayer_analyzer/analysis_protocols.py
+++ b/pybilt/bilayer_analyzer/analysis_protocols.py
@@ -562,6 +562,7 @@ class MSDProtocol(AnalysisProtocol):
         self.settings = dict()
         self.settings['leaflet'] = 'both'
         self.settings['resname'] = 'all'
+        # self.settings['time_block'] = None
         self._valid_settings = list(self.settings.keys())
         #self.leaflet = 'both'
         #self.resname = 'all'
@@ -614,12 +615,11 @@ class MSDProtocol(AnalysisProtocol):
             count += 1
 
         # initialize a numpy array to hold the msd for the selection
-        msd = np.zeros(2)
+        msd = np.zeros(3)
         # initialize a running stats object to do the averaging over resids
         drs_stat = RunningStats()
 
         ref_coords = np.zeros((n_com, 2))
-
 
         if self._first_frame:
             count = 0
@@ -636,12 +636,20 @@ class MSDProtocol(AnalysisProtocol):
             ref_coords = self._ref_coords
             # get the current com frame list
         tc = ba_reps['com_frame'].time
-        if (tc - self._ref_time) >= 50000.0:
-            self._ref_coords = selcoords[:]
-            ref_coords = selcoords[:]
-            self._ref_time = tc
-            print("updating ref_coords at time {}".format(tc))
+#        if (tc - self._ref_time) >= 50000.0:
+#            self._ref_coords = selcoords[:]
+#            ref_coords = selcoords[:]
+#            self._ref_time = tc
+#            print("updating ref_coords at time {}".format(tc))
             # quit()
+#        if len(self.analysis_output) > 1:
+#            tp = self.analysis_output[-1][0]
+#            ic = ba_reps['com_frame'].number
+#            ip = self.analysis_output[-1][2]
+#            difft = tc - tp
+#            if difft > 200.0:
+#                print('diffhigh ', tc, tp, difft, ic, ip)
+                #quit()
         dt = tc
         dr = selcoords - ref_coords
         drs = dr * dr
@@ -654,6 +662,7 @@ class MSDProtocol(AnalysisProtocol):
         msdcurr = drs_stat.mean()
         msd[0] = dt
         msd[1] = msdcurr
+        msd[2] = ba_reps['com_frame'].number
         self.analysis_output.append(msd)
         return
 

--- a/pybilt/bilayer_analyzer/analysis_protocols.py
+++ b/pybilt/bilayer_analyzer/analysis_protocols.py
@@ -145,7 +145,7 @@ class Analyses(object):
                 the calling BilayerAnalyzer class object.
 
         """
-        self.use_objects = use_objects
+        self.use_objects = use_objects.copy()
         self.in_commands = analysis_commands
         self.arguments = []
         self.analysis_keys = []
@@ -615,7 +615,7 @@ class MSDProtocol(AnalysisProtocol):
             count += 1
 
         # initialize a numpy array to hold the msd for the selection
-        msd = np.zeros(3)
+        msd = np.zeros(2)
         # initialize a running stats object to do the averaging over resids
         drs_stat = RunningStats()
 
@@ -662,7 +662,7 @@ class MSDProtocol(AnalysisProtocol):
         msdcurr = drs_stat.mean()
         msd[0] = dt
         msd[1] = msdcurr
-        msd[2] = ba_reps['com_frame'].number
+        #msd[2] = ba_reps['com_frame'].number
         self.analysis_output.append(msd)
         return
 

--- a/pybilt/bilayer_analyzer/bilayer_analyzer.py
+++ b/pybilt/bilayer_analyzer/bilayer_analyzer.py
@@ -668,6 +668,7 @@ class BilayerAnalyzer(object):
         self._mda_data.update_trajectory(new_trajectory)
         if reset_iterator:
             self._current_frame = self.settings['frame_range'][0]
+            self._last_frame = self._mda_data.nframes
         return
 
     # buildable objects functions

--- a/pybilt/bilayer_analyzer/prefab_analysis_protocols.py
+++ b/pybilt/bilayer_analyzer/prefab_analysis_protocols.py
@@ -485,9 +485,9 @@ def thickness_grid(structure_file, trajectory_file, selection_string,
 
     analyzer.print_analysis_protocol()
     # add the plot
-    analyzer.add_plot("thickness_grid bt_p bt None")
+    #analyzer.add_plot("bilayer_thickness bt_p bt None")
 
-    analyzer.print_plot_protocol()
+    #analyzer.print_plot_protocol()
 
     # run analysis
     for dummy_frame in analyzer:
@@ -508,7 +508,7 @@ def thickness_grid(structure_file, trajectory_file, selection_string,
 
     # output data and plots
     analyzer.dump_data(path=dump_path)
-    analyzer.save_all_plots()
+    #analyzer.save_all_plots()
     # output final ensemble average to stdout
     bt = analyzer.get_analysis_data('bt')
     print(("Bilayer thickness from gridding procedure (Angstrom): {:0.4f} +- {:0.4f}".format(bt[-1][2], bt[-1][3])))

--- a/pybilt/common/running_stats.py
+++ b/pybilt/common/running_stats.py
@@ -349,6 +349,18 @@ class BlockAverager(object):
                     n_block += 1
             return n_block
 
+def block_average_bse_v_size(data):
+    n_dat = len(data)
+    max_size = int(n_dat/3)
+    output = list()
+    for i in range(1, max_size+1, 1):
+        block_averager = BlockAverager(points_per_block=i, min_points_in_block=i)
+        block_averager.push_container(data)
+        avg, std_error = block_averager.get()
+        print(i/10, avg, std_error)
+        output.append([i, avg, std_error])
+    return np.array(output)
+
 def binned_average(data, positions, n_bins=25, position_range=None, min_count=0):
     """Compute averages over a quantized range of histogram like bins.
 

--- a/pybilt/lipid_grid/lipid_grid_opt.py
+++ b/pybilt/lipid_grid/lipid_grid_opt.py
@@ -493,9 +493,14 @@ class LipidGrids(object):
                                               area_per_bin=area_per_bin)
         return
 
-    def thickness_grid(self):
+    def thickness_grid(self, use_gaussian_filter=False, filter_sigma=10.0, filter_mode='nearest'):
         tgrid = np.zeros((self.nbins_x, self.nbins_y))
-        tgrid = self.leaf_grid['upper'].lipid_grid_z - self.leaf_grid['lower'].lipid_grid_z
+        if use_gaussian_filter:
+            upper = gaussian_filter(self.leaf_grid['upper'].lipid_grid_z, filter_sigma, mode=filter_mode)
+            lower = gaussian_filter(self.leaf_grid['lower'].lipid_grid_z, filter_sigma, mode=filter_mode)
+            tgrid = upper - lower
+        else:
+            tgrid = self.leaf_grid['upper'].lipid_grid_z - self.leaf_grid['lower'].lipid_grid_z
         # for ix in range(self.nbins_x):
         #     for iy in range(self.nbins_y):
         #         zu = self.leaf_grid['upper'].get_z_at(ix, iy)

--- a/tests/test_ba_com_lateral_rdf.py
+++ b/tests/test_ba_com_lateral_rdf.py
@@ -23,7 +23,7 @@ def test_ba_com_lateral_rdf():
     ba.set_frame_range(first=0, last=-1, interval=100)
     ba.rep_settings['com_frame']['name_dict'] = {'DOPE':['P'],'POPC':['P'],'TLCL2':['C2']}
     ba.settings['print_interval'] = 1
-    print "frame_range: ",ba.settings['frame_range']
+    print("frame_range: ",ba.settings['frame_range'])
     ba.run_analysis()
     print('com_lateral_rdf: ')
     rdf, bins = ba.get_analysis_data('com_lateral_rdf')

--- a/tests/test_ba_prefab_protocol_bilayer_thickness.py
+++ b/tests/test_ba_prefab_protocol_bilayer_thickness.py
@@ -1,15 +1,16 @@
-from pybilt.bilayer_analyzer.prefab_analysis_protocols import bilayer_thickness
+from pybilt.bilayer_analyzer.prefab_analysis_protocols import thickness_grid
 
 
 def test_analysis_module_bilayer_thickness():
     sel_string = "resname POPC DOPE TLCL2"
     name_dict = {'DOPE':['P'],'POPC':['P'],'TLCL2':['P1','P3']}
-    bilayer_thickness(structure_file='../pybilt/sample_bilayer/sample_bilayer.psf',
-                  trajectory_file='../pybilt/sample_bilayer/sample_bilayer_10frames.dcd',
-                  selection_string=sel_string,
-                  name_dict=name_dict,
-                  frame_start=0, frame_end=-2, frame_interval=2,
-                  n_xbins=100, n_ybins=100)
+    thickness_grid(structure_file='../pybilt/sample_bilayer/sample_bilayer.psf',
+                   trajectory_file='../pybilt/sample_bilayer/sample_bilayer_10frames.dcd',
+                   selection_string=sel_string,
+                   name_dict=name_dict,
+                   frame_start=0, frame_end=-2, frame_interval=2,
+                   n_xbins=100, n_ybins=100,
+                   plot_grid_map=False)
 
     return
 


### PR DESCRIPTION
I added in a function to the running_stats module to compute the blocked standard error (BSE) vs the block size. This branch also includes some miscellaneous bug and other fixes found during testing, as well as removal of some other custom code changes put in for debugging when I used this branch code for analyses. 

All the tests pass under Python 2.7. I think some may fail under 3.6, but I'll tackle this in another branch and PR.